### PR TITLE
Removed _S from modus ponens and deduction definition

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -335,9 +335,9 @@
         "stepnr": "Step"
       },
       "deduction": {
-        "def": "$$\\bigl(\\sum,\\phi\\vdash_S\\psi\\bigr) \\Rightarrow \\bigl(\\sum\\vdash_S\\phi\\rightarrow\\psi\\bigr)$$",
-        "n1": "$$\\sum,\\phi\\vdash_S\\psi$$",
-        "n2": "$$\\sum\\vdash_S\\phi\\rightarrow\\psi$$",
+        "def": "$$\\bigl(\\sum,\\phi\\vdash\\psi\\bigr) \\Rightarrow \\bigl(\\sum\\vdash\\phi\\rightarrow\\psi\\bigr)$$",
+        "n1": "$$\\sum,\\phi\\vdash\\psi$$",
+        "n2": "$$\\sum\\vdash\\phi\\rightarrow\\psi$$",
         "phi": "$$\\phi$$"
       },
       "goal": {
@@ -353,10 +353,10 @@
         "stepnr": "Step"
       },
       "modusponens": {
-        "def": "$$\\bigl(\\sum\\vdash_S\\phi\\bigr), \\bigl(\\Delta\\vdash_S\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash_S\\psi$$",
-        "n1": "$$\\sum\\vdash_S\\phi$$",
-        "n2": "$$\\Delta\\vdash_S\\phi\\rightarrow\\psi$$",
-        "n3": "$$\\sum\\cup\\Delta\\vdash_S\\psi$$"
+        "def": "$$\\bigl(\\sum\\vdash\\phi\\bigr), \\bigl(\\Delta\\vdash\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash\\psi$$",
+        "n1": "$$\\sum\\vdash\\phi$$",
+        "n2": "$$\\Delta\\vdash\\phi\\rightarrow\\psi$$",
+        "n3": "$$\\sum\\cup\\Delta\\vdash\\psi$$"
       }
     },
     "title": "Prove Axiomatic"

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -335,9 +335,9 @@
         "stepnr": "Stap"
       },
       "deduction": {
-        "def": "$$\\bigl(\\sum,\\phi\\vdash_S\\psi\\bigr) \\Rightarrow \\bigl(\\sum\\vdash_S\\phi\\rightarrow\\psi\\bigr)$$",
-        "n1": "$$\\sum,\\phi\\vdash_S\\psi$$",
-        "n2": "$$\\sum\\vdash_S\\phi\\rightarrow\\psi$$",
+        "def": "$$\\bigl(\\sum,\\phi\\vdash\\psi\\bigr) \\Rightarrow \\bigl(\\sum\\vdash\\phi\\rightarrow\\psi\\bigr)$$",
+        "n1": "$$\\sum,\\phi\\vdash\\psi$$",
+        "n2": "$$\\sum\\vdash\\phi\\rightarrow\\psi$$",
         "phi": "$$\\phi$$"
       },
       "goal": {
@@ -353,10 +353,10 @@
         "stepnr": "Stap"
       },
       "modusponens": {
-        "def": "$$\\bigl(\\sum\\vdash_S\\phi\\bigr), \\bigl(\\Delta\\vdash_S\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash_S\\psi$$",
-        "n1": "$$\\sum\\vdash_S\\phi$$",
-        "n2": "$$\\Delta\\vdash_S\\phi\\rightarrow\\psi$$",
-        "n3": "$$\\sum\\cup\\Delta\\vdash_S\\psi$$"
+        "def": "$$\\bigl(\\sum\\vdash\\phi\\bigr), \\bigl(\\Delta\\vdash\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash\\psi$$",
+        "n1": "$$\\sum\\vdash\\phi$$",
+        "n2": "$$\\Delta\\vdash\\phi\\rightarrow\\psi$$",
+        "n3": "$$\\sum\\cup\\Delta\\vdash\\psi$$"
       }
     },
     "title": "Bewijs Axiomatisch"


### PR DESCRIPTION
Resolves #220 
Test [here](https://www.bendevries.com/logictools/220_remove_s)
Dit lost ook het probleem op dat de regeldefinities over twee regels staan