### PR TITLE
Added call for lemma.close

### DIFF
--- a/src/html/logax.html
+++ b/src/html/logax.html
@@ -300,6 +300,13 @@
 									<span translate-key="logax.rule.lemma.stepExp"></span>
 								</td>
 							</tr>
+							<!-- Lemma Close -->
+							<tr rule="logic.propositional.axiomatic.lemma.close" id="lemma-close-stepnr" style="display: none">
+								<td><span translate-key="logax.rule.lemma.closeStepnr" class="float-right"></span></td><td>
+									<select id="lemma-select-close-stepnr" class="form-control input custom-select stepnr-select">
+									</select>
+								</td>
+							</tr>
 						</tbody>
 					</table>
 					<!-- <tr >

--- a/src/js/controller/LogAxController.js
+++ b/src/js/controller/LogAxController.js
@@ -674,6 +674,17 @@ export class LogAxController extends ExerciseController {
           }
         }
       }
+      case 'logic.propositional.axiomatic.lemma.close': {
+        const stepnr = document.getElementById('lemma-select-close-stepnr')
+
+        return {
+          environment: {
+            n: stepnr.value,
+            st: this.exercise.lemmas[0]
+          },
+          rule: rule
+        }
+      }
     }
   }
 
@@ -798,6 +809,13 @@ export class LogAxController extends ExerciseController {
         applyButton.disabled = false
         break
       }
+      case 'logic.propositional.axiomatic.lemma.close': {
+        const stepnr = document.getElementById('lemma-select-close-stepnr')
+        if (stepnr.value !== '') {
+          applyButton.disabled = false
+        }
+        break
+      }
     }
   }
 
@@ -889,6 +907,9 @@ export class LogAxController extends ExerciseController {
         }
       }
       case 'logic.propositional.axiomatic.lemma': {
+        return true
+      }
+      case 'logic.propositional.axiomatic.lemma.close': {
         return true
       }
     }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -349,9 +349,9 @@
       },
       "label": "<b>Rule</b>",
       "lemma": {
+        "closeStepnr": "Step",
         "stepExp": "Specify the number of the new step, or leave empty to get a default number",
-        "stepnr": "Step",
-        "closeStepnr": "Step"
+        "stepnr": "Step"
       },
       "modusponens": {
         "def": "$$\\bigl(\\sum\\vdash\\phi\\bigr), \\bigl(\\Delta\\vdash\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash\\psi$$",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -350,7 +350,8 @@
       "label": "<b>Rule</b>",
       "lemma": {
         "stepExp": "Specify the number of the new step, or leave empty to get a default number",
-        "stepnr": "Step"
+        "stepnr": "Step",
+        "closeStepnr": "Step"
       },
       "modusponens": {
         "def": "$$\\bigl(\\sum\\vdash\\phi\\bigr), \\bigl(\\Delta\\vdash\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash\\psi$$",

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -349,9 +349,9 @@
       },
       "label": "<b>Regel</b>",
       "lemma": {
+        "closeStepnr": "Stap",
         "stepExp": "Geef het nummer van de nieuwe stap, of laat leeg om automatisch een nummer te bepalen",
-        "stepnr": "Stap",
-        "closeStepnr": "Stap"
+        "stepnr": "Stap"
       },
       "modusponens": {
         "def": "$$\\bigl(\\sum\\vdash\\phi\\bigr), \\bigl(\\Delta\\vdash\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash\\psi$$",

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -350,7 +350,8 @@
       "label": "<b>Regel</b>",
       "lemma": {
         "stepExp": "Geef het nummer van de nieuwe stap, of laat leeg om automatisch een nummer te bepalen",
-        "stepnr": "Stap"
+        "stepnr": "Stap",
+        "closeStepnr": "Stap"
       },
       "modusponens": {
         "def": "$$\\bigl(\\sum\\vdash\\phi\\bigr), \\bigl(\\Delta\\vdash\\phi\\rightarrow\\psi\\bigr) \\Rightarrow \\sum\\cup\\Delta\\vdash\\psi$$",


### PR DESCRIPTION
Resolves #228 
Test [here](https://www.bendevries.com/logictools/228_lemma_motivation)

Deze lijkt niet te werken zoals verwacht. Misschien is dit dat de backend de lemma.close regel fout toepast. Ik stuur 
```
{
  "n": "1000",
  "st": "~~p |- ~p -> ~~~p"
}
```
Met `n` als de stap die ik wil motiveren en `st` als de tekst van de lemma maar het lijkt dat het de tekst van stap `n` met de tekst van de lemma overschrijft.