### PR TITLE
Added method to automatically select exercise through URL

### DIFF
--- a/src/js/controller/OneWayController.js
+++ b/src/js/controller/OneWayController.js
@@ -37,6 +37,7 @@ function ready (fn) {
 function setUp () {
   const controller = new OneWayController()
   window.translate = loadLanguage
+  window.controller = controller
   loadLanguage(LogEXSession.getLanguage())
   controller.initializeRuleJustification()
   controller.initializeStepValidation()

--- a/src/js/controller/TwoWayController.js
+++ b/src/js/controller/TwoWayController.js
@@ -37,6 +37,7 @@ function ready (fn) {
 function setUp () {
   const controller = new TwoWayController()
   window.translate = loadLanguage
+  window.controller = controller
   loadLanguage(LogEXSession.getLanguage())
   controller.initializeStepValidation()
   controller.initializeInput()


### PR DESCRIPTION
Resolves #277
Test [here](https://www.bendevries.com/logictools/277_select_url)

Je kunt een opgave selecteren met bijvoorbeeld https://www.bendevries.com/logictools/277_select_url?tool=dnf&exercise=1 . Het is zo ingesteld dat de `1` de opgavenummer van de backend is en er wordt 1 bij opgeteld voor de gebruiker. Dit kan dus afwijken van de opgave 2 dat in de tool te selecteren is. 

Ik kan het maken dat `1` dus de tweede voorbeeldopgave is zoals gedefinieerd in de `config.json`. Maar ik weet niet wat het handigst is.