### PR TITLE
Add highlighting steps to LogInd

### DIFF
--- a/src/html/logind.html
+++ b/src/html/logind.html
@@ -214,16 +214,16 @@
 		<script id="exercise-active-top-step-template" type="text/x-jsrender">
 			{{if relation !== null || motivation !== null}}
 			<tr class="case-step-row">
-				<td>{{if relation !== null}}
+				<td {{if highlightRelation}}class="highlight-text"{{/if}}>{{if relation !== null}}
 					{{:relation}}
 				{{/if}}</td>
-				<td>{{if motivation !== null}}
+				<td {{if highlightRule}}class="highlight-text"{{/if}}>{{if motivation !== null}}
 					(<span translate-key="rule.logic.propositional.logind.{{:motivation}}" translate-params='{{:motivationParams}}'></span>)
 				{{/if}}</td>
 			</tr>
 			{{/if}}
 			<tr class="case-step-row">
-				<td colspan="2">
+				<td colspan="2" {{if highlightTerm}}class="highlight-text"{{/if}}>
 					{{:formula}}
 					{{if !isFirst}}
 						<button type="button" class="btn btn-outline-secondary btn-sm float-right delete-step"><i class='fas fa-times'></i></button>
@@ -234,16 +234,16 @@
 		<script id="exercise-active-bottom-step-template" type="text/x-jsrender">
 			{{if relation !== null || motivation !== null}}
 			<tr class="case-step-row">
-				<td>{{if relation !== null}}
+				<td {{if highlightRelation}}class="highlight-text"{{/if}}>{{if relation !== null}}
 					{{:relation}}
 				{{/if}}</td>
-				<td>{{if motivation !== null}}
+				<td {{if highlightRule}}class="highlight-text"{{/if}}>{{if motivation !== null}}
 					(<span translate-key="rule.logic.propositional.logind.{{:motivation}}" translate-params='{{:motivationParams}}'></span>)
 				{{/if}}</td>
 			</tr>
 			{{/if}}
 			<tr class="case-step-row">
-				<td colspan="2">
+				<td colspan="2" {{if highlightTerm}}class="highlight-text"{{/if}}>
 					{{:formula}}
 					{{if !isLast}}
 						<button type="button" class="btn btn-outline-secondary btn-sm float-right delete-step"><i class='fas fa-times'></i></button>
@@ -258,10 +258,10 @@
 				<tr class="border-middle-{{:border}}">
 			{{/if}}
 			<!-- <td>{{:relation}}{{if relation === null && !isFirst}}={{/if}}</td> -->
-			<td>{{:relation}}</td>
-			<td>{{if isEmptyFormula}}<i class="placeholder-text">formula</i>{{else}}{{:formula}}{{/if}}</td>
+			<td {{if highlightRelation}}class="highlight-text"{{/if}}>{{:relation}}</td>
+			<td {{if highlightTerm}}class="highlight-text"{{/if}}>{{if isEmptyFormula}}<i class="placeholder-text">formula</i>{{else}}{{:formula}}{{/if}}</td>
 			<!-- <td>{{if motivation !== null}}({{:motivation}}){{else !isFirst}}(?){{/if}}</td> -->
-			<td>{{if motivation !== null}}
+			<td {{if highlightRule}}class="highlight-text"{{/if}}>{{if motivation !== null}}
 				(<span translate-key="rule.logic.propositional.logind.{{:motivation}}" translate-params='{{:motivationParams}}'></span>)
 			{{/if}}</td>
 			</tr>

--- a/src/js/controller/LogIndController.js
+++ b/src/js/controller/LogIndController.js
@@ -780,6 +780,9 @@ export class LogIndController extends ExerciseController {
 
     const exerciseStepHtml = stepTemplate.render({
       border: border,
+      highlightRelation: step.highlightRelation,
+      highlightTerm: step.highlightTerm,
+      highlightRule: step.highlightRule,
       isEmptyFormula: step.term === '',
       isFirst: step.number === 0,
       isTopStep: step.isTopStep,

--- a/src/js/model/logind/exercise.js
+++ b/src/js/model/logind/exercise.js
@@ -52,6 +52,7 @@ export class LogIndExercise {
     for (const _case of this.cases.cases) {
       oldIdentifiers.push(_case.identifier)
     }
+    const oldCases = this.cases
     this.cases = new LogIndCaseCollection(this, cases)
     if (activeCase) {
       this.activeCase = this.cases.cases.find(x => x.identifier === activeCase)
@@ -62,6 +63,41 @@ export class LogIndExercise {
         if (!oldIdentifiers.includes(_case.identifier)) {
           this.activeCase = _case
           break
+        }
+      }
+    }
+    for (const _case of this.cases.cases) {
+      if (!oldIdentifiers.includes(_case.identifier)) {
+        for (const step of _case.steps) {
+          step.highlightRelation = true
+          step.highlightTerm = true
+          step.highlightRule = true
+        }
+      } else {
+        const oldCase = oldCases.cases.find(x => x.identifier === _case.identifier)
+        for (const step of _case.steps) {
+          let oldStep = null
+          if (step.isTopStep) {
+            if (_case.steps[_case.steps.length - 1].isTopStep) { // case complete
+              oldStep = oldCase.steps.find(x => x.number === step.number)
+            } else {
+              oldStep = oldCase.steps.find(x => x.number === step.number && x.isTopStep === true)
+            }
+          } else {
+            oldStep = oldCase.steps.find(x => oldCase.steps.length - x.number === _case.steps.length - step.number)
+            // if (oldStep.isTopStep) {
+            //   continue
+            // }
+          }
+          if (oldStep === undefined || step.relation !== oldStep.relation) {
+            step.highlightRelation = true
+          }
+          if (oldStep === undefined || step.term !== oldStep.term) {
+            step.highlightTerm = true
+          }
+          if (oldStep === undefined || step.rule !== oldStep.rule) {
+            step.highlightRule = true
+          }
         }
       }
     }

--- a/src/js/model/logind/step.js
+++ b/src/js/model/logind/step.js
@@ -25,7 +25,7 @@ export class LogIndStep {
     this.isTopStep = isTopStep
 
     // Highlights
-    this.highlightStep = false
+    this.highlightRelation = false
     this.highlightTerm = false
     this.highlightRule = false
   }

--- a/src/js/translate.js
+++ b/src/js/translate.js
@@ -70,7 +70,6 @@ class Translate {
     // Find all cases of {{param}}.
     const paramRegex = /\{\{([^{]*?)\}\}/g
     string = string.replace(paramRegex, function (match, token) {
-      console.log(typeof params[token], params[token])
       if (typeof params[token] === 'object') {
         return params[token][language]
       }


### PR DESCRIPTION
Resolves #313 
Test [here](https://www.bendevries.com/logictools/313_mark_new)

Deze werkt niet als je hints gebruikt bij een opgave waar de backend hints geeft na de `<GAP>` bijvoorbeeld de basisgevallen van opgaven 10. Ik weet niet of dit wel de bedoelde werking van de backend is, als je het basisgeval zelf wil sluiten moet je rekenen als motivatie kiezen en de hint heeft nog geen tekst.

<img width="1193" alt="Screen Shot 2022-01-12 at 22 23 25" src="https://user-images.githubusercontent.com/10991906/149223605-eb6364f8-5dc8-4927-9d77-d13140fb5436.png">
.