### PR TITLE
Require correct case type

### DIFF
--- a/src/js/controller/LogIndController.js
+++ b/src/js/controller/LogIndController.js
@@ -326,10 +326,10 @@ export class LogIndController extends ExerciseController {
     if (this.proofDirection === 'begin') {
       newExercise.activeCase = new LogIndCase(
         newExercise,
+        this.exercise.activeCase.type,
         this.exercise.activeCase.getObject(),
         this.exercise.activeCase.index,
-        this.exercise.activeCase.identifier,
-        this.exercise.activeCase.type
+        this.exercise.activeCase.identifier
       )
       let relation = document.getElementById('relation-gap').value
       if (relation === '≤') {
@@ -388,13 +388,11 @@ export class LogIndController extends ExerciseController {
         nextStep.rule = document.getElementById('motivation-bottom').value
       }
     }
-
     this.exerciseValidator.validateExercise(this.exercise, newExercise.getObject(), this.onStepValidated.bind(this), this.onErrorValidatingStep.bind(this))
   }
 
   newCase (type) {
-    this.exercise.activeCase = new LogIndCase(this.exercise)
-    this.exercise.activeCase.type = type
+    this.exercise.activeCase = new LogIndCase(this.exercise, type)
     this.setProofDirection('begin')
     this.setStep()
     this.updateSteps()
@@ -595,21 +593,7 @@ export class LogIndController extends ExerciseController {
         }
         if (term.includes('connective not in language')) {
           const connective = term.split(':')[3].trim()
-          let connectiveLatex = null
-          switch (connective) {
-            case 'NEGATION':
-              connectiveLatex = '\\neg'
-              break
-            case 'OR':
-              connectiveLatex = '\\lor'
-              break
-            case 'AND':
-              connectiveLatex = '\\land'
-              break
-            case 'IMPLIES':
-              connectiveLatex = '\\rightarrow'
-              break
-          }
+          let connectiveLatex = this.getOperatorLatex(connective)
           this.setErrorLocation(this.proofDirection === 'up' ? 'formula-bottom' : 'formula-top')
           this.updateAlert('logind.error.noConnective', { connective: connectiveLatex }, 'error')
           break
@@ -672,23 +656,36 @@ export class LogIndController extends ExerciseController {
         }
         if (term.includes('double case')) {
           const _case = term.split(':')[1].split(' ')[2].trim()
-          let caseLatex = null
-          switch (_case) {
-            case 'NEGATION':
-              caseLatex = '\\neg'
-              break
-            case 'OR':
-              caseLatex = '\\lor'
-              break
-            case 'AND':
-              caseLatex = '\\land'
-              break
-            case 'IMPLIES':
-              caseLatex = '\\rightarrow'
-              break
-          }
+          let caseLatex = this.getOperatorLatex(_case)
           this.setErrorLocation(['formula-bottom', 'formula-top'])
           this.updateAlert('logind.error.doubleCase', { case: caseLatex }, 'error')
+          break
+        }
+
+        if (term.includes('but basestep')) {
+          const _case = term.split(' ')[2].trim()
+          const identifier = term.split(' ')[5].trim()
+
+          this.setErrorLocation(['formula-bottom', 'formula-top'])
+          this.updateAlert('logind.error.butBasestep', { identifier: identifier, case: `logind.case.type.${_case}` }, 'error')
+          break
+        }
+
+        if (term.includes('but ihstep')) {
+          const _case = term.split(' ')[2].trim()
+          const identifier = term.split(' ')[5].trim()
+
+          this.setErrorLocation(['formula-bottom', 'formula-top'])
+          this.updateAlert('logind.error.butIhstep', { identifier: `\\${identifier}`, case: `logind.case.type.${_case}` }, 'error')
+          break
+        }
+
+        if (term.includes('but inductivestep')) {
+          const _case = term.split(' ')[2].trim()
+          const identifier = term.split(' ')[5].trim()
+
+          this.setErrorLocation(['formula-bottom', 'formula-top'])
+          this.updateAlert('logind.error.butInductivestep', { identifier: this.getOperatorLatex(identifier), case: `logind.case.type.${_case}` }, 'error')
           break
         }
 
@@ -710,6 +707,19 @@ export class LogIndController extends ExerciseController {
     return {
       key: 'rule.logic.propositional.logind.definition',
       params: { function: motivation }
+    }
+  }
+
+  getOperatorLatex(term) {
+    switch (term) {
+      case 'NEGATION':
+        return '\\neg'
+      case 'OR':
+        return '\\lor'
+      case 'AND':
+        return '\\land'
+      case 'IMPLIES':
+        return '\\rightarrow'
     }
   }
 

--- a/src/js/controller/mainFrameController.js
+++ b/src/js/controller/mainFrameController.js
@@ -99,7 +99,6 @@ class MainFrameController {
     if (tool === null) {
       document.getElementById('container-welcome').classList.add('active')
       selectTool('welcome', 'welcome.html')
-      console.log('hello')
       return
     }
     for (const entry of urlParams.entries()) {

--- a/src/js/model/logind/exercise.js
+++ b/src/js/model/logind/exercise.js
@@ -40,9 +40,9 @@ export class LogIndExercise {
       active: null
     }
     if (this.activeCase !== null) {
-      object.active = this.activeCase.identifier
-      if (this.activeCase.steps.some((step) => step.term !== '') && this.activeCase.identifier === '') {
-        object.proofs[''] = this.activeCase.getObject()
+      object.active = ''
+      if (this.activeCase.steps.some((step) => step.term !== '') && ['basestep', 'ihstep', 'inductivestep'].includes(this.activeCase.identifier)) {
+        object.proofs[this.activeCase.identifier] = this.activeCase.getObject()
       }
     }
     return object

--- a/src/js/model/logind/stepCollection.js
+++ b/src/js/model/logind/stepCollection.js
@@ -16,14 +16,14 @@ export class LogIndCaseCollection {
       let j = 0
       let k = 0
       for (const [identifier, _case] of Object.entries(cases)) {
-        if (['p', 'q', 'r', 's'].includes(identifier)) {
-          this.baseCases.push(new LogIndCase(this.exercise, _case, i, identifier, 'baseCase'))
+        if (['basestep', 'p', 'q', 'r', 's'].includes(identifier)) {
+          this.baseCases.push(new LogIndCase(this.exercise, 'baseCase', _case, i, identifier))
           i++
-        } else if (['psi', 'phi', 'chi'].includes(identifier)) {
-          this.hypotheses.push(new LogIndCase(this.exercise, _case, j, identifier, 'hypothesis'))
+        } else if (['ihstep', 'psi', 'phi', 'chi'].includes(identifier)) {
+          this.hypotheses.push(new LogIndCase(this.exercise, 'hypothesis', _case, j, identifier))
           j++
         } else {
-          this.inductiveSteps.push(new LogIndCase(this.exercise, _case, k, identifier, 'inductiveStep'))
+          this.inductiveSteps.push(new LogIndCase(this.exercise, 'inductiveStep', _case, k, identifier))
           k++
         }
       }
@@ -59,7 +59,7 @@ const IDENTIFIERS = {
 }
 
 export class LogIndCase extends StepCollection {
-  constructor (exercise, _case, index, identifier, type) {
+  constructor (exercise, type, _case, index, identifier) {
     super()
     this.exercise = exercise
     this.index = index
@@ -69,7 +69,19 @@ export class LogIndCase extends StepCollection {
     this.proofRelation = exercise.theorem[1].type
     this.isCollapsed = false
     if (identifier === undefined) {
-      this.identifier = ''
+      switch (type) {
+        case 'baseCase':
+          this.identifier = 'basestep'
+          break
+        case 'hypothesis':
+          this.identifier = 'ihstep'
+          break
+        case 'inductiveStep':
+          this.identifier = 'inductivestep'
+          break
+        default:
+          this.identifier = ''
+      }
     }
 
     if (_case === undefined) {

--- a/src/lang/nl.json
+++ b/src/lang/nl.json
@@ -430,10 +430,18 @@
         "no_base_case": "U heeft geen basisgevallen geschreven.",
         "no_hypotheses": "U heeft geen hypotheses geschreven.",
         "no_inductive_steps": "U heeft geen inductiestappen geschreven."
+      },
+      "type": {
+        "basestep": "basisgeval",
+        "ihstep": "inductiehypothese",
+        "inductivestep": "inductief geval"
       }
     },
     "completed": "De uitwerking is compleet",
     "error": {
+      "butBasestep": "Dit is geen [[case]] maar een basis geval voor {{identifier}}",
+      "butIhstep": "Dit is geen [[case]] maar een inductiehypothese voor $${{identifier}}$$",
+      "butInductivestep": "Dit is geen [[case]] maar een inductief geval $${{identifier}}$$",
       "caseNotRecognized": "Dit is geen correct geval",
       "checkDifferentMetavars": "Gebruik steeds dezelfde metavariabelen in dit inductieve geval.",
       "differentMetaVars": "In het linker- en rechterdeel van de inductiehypothese moet dezelfde variabele voorkomen.",


### PR DESCRIPTION
Resolves #369 
Test [here](https://www.bendevries.com/logictools/369_case_labels)

Als je "nieuw hypothese" klikt en dan een basisgeval of een inductiestap toepas krijg je geen `not   ihstep  but basestep  p` foutmelding maar `check-triple.UserStep \"ihstep\" (Just (BaseStep \"p\")) linenr:0:no meta var in hypothesis`.